### PR TITLE
fix: apply cargo fmt formatting

### DIFF
--- a/src/commands/plan.rs
+++ b/src/commands/plan.rs
@@ -191,7 +191,10 @@ pub fn run(
                     // No structured_output - try Haiku fallback on the raw stdout
                     app.status = "No structured_output, trying Haiku normalization...".to_string();
                     terminal.draw(|f| app.draw(f)).expect("Failed to draw");
-                    app.push_log("Tier 1 failed: No structured_output in wrapper. Trying Haiku...".to_string());
+                    app.push_log(
+                        "Tier 1 failed: No structured_output in wrapper. Trying Haiku..."
+                            .to_string(),
+                    );
 
                     match normalize_json_with_haiku(&stdout, PLAN_RESPONSE_SCHEMA) {
                         Ok(normalized) => match serde_json::from_str(&normalized) {

--- a/src/plan/app.rs
+++ b/src/plan/app.rs
@@ -400,7 +400,10 @@ impl PlanApp {
             let total = self.submitted_total;
             vec![
                 Span::styled(" | Submitted: ", Style::default().fg(Color::Gray)),
-                Span::styled(format!("{}/{}", answered, total), Style::default().fg(Color::Green)),
+                Span::styled(
+                    format!("{}/{}", answered, total),
+                    Style::default().fg(Color::Green),
+                ),
             ]
         } else if self.phase == PlanPhase::Asking && !self.questions.is_empty() {
             let answered = self.answered_count();


### PR DESCRIPTION
Fixes CI formatting check failure by running cargo fmt on the two files with long lines.